### PR TITLE
Additional robustness improvements

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,11 @@
 # Revision history for aeson-gadt-th
 
+## 0.2.1.0
+
+* Extend type variable substitution to handle all current cases in template-haskell.
+* Better deal with data constructors having an index that is polymorphic, but can be determined from the other type parameters.
+* Handle data constructors that are constrained by type classes.
+
 ## 0.2.0.0
 
 * Add changelog

--- a/README.md
+++ b/README.md
@@ -32,8 +32,12 @@ data B c :: * -> * where
   B_a :: c -> A a -> B c a
   B_x :: B c a
 
+data C t :: * -> * where
+  C_t :: t -> C t t
+
 deriveJSONGADT ''A
 deriveJSONGADT ''B
+deriveJSONGADT ''C
 
 -- Some real-world-ish examples.
 

--- a/README.md
+++ b/README.md
@@ -12,9 +12,6 @@ Provides Template Haskell expressions for deriving `ToJSON` and `FromJSON` insta
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE PolyKinds #-}
-
-{-# OPTIONS_GHC -ddump-splices #-}
 
 import Data.Aeson
 import Data.Aeson.GADT.TH
@@ -50,7 +47,7 @@ data LabelledGraphEdit v vm em :: * -> * where
   LabelledGraphEdit_SetEdgeProperties :: v -> v -> em -> LabelledGraphEdit v vm em ()
 
 -- | PropertyGraphEdit operatios for `PropertyGraph`
-data PropertyGraphEdit v (vp :: * -> *) ep r where
+data PropertyGraphEdit v vp ep r where
   PropertyGraphEdit_ClearAll :: PropertyGraphEdit v vp ep ()
   PropertyGraphEdit_AddVertex :: (DMap vp Identity) -> PropertyGraphEdit v vp ep v
   PropertyGraphEdit_AddEdge :: v -> v -> (DMap ep Identity) -> PropertyGraphEdit v vp ep ()

--- a/aeson-gadt-th.cabal
+++ b/aeson-gadt-th.cabal
@@ -16,6 +16,7 @@ library
   exposed-modules: Data.Aeson.GADT.TH
   build-depends: base >= 4.8 && < 4.13
                , aeson
+               , containers
                , dependent-sum
                , transformers
                , template-haskell

--- a/src/Data/Aeson/GADT/TH.hs
+++ b/src/Data/Aeson/GADT/TH.hs
@@ -36,9 +36,8 @@ import Data.Aeson
 import Data.List
 import Data.Maybe
 import qualified Data.Set as Set
-import Data.Set (Set)
 import Data.Some (Some (..))
-import Language.Haskell.TH
+import Language.Haskell.TH hiding (cxt)
 
 newtype JSONGADTOptions = JSONGADTOptions
   { gadtConstructorModifier :: String -> String }
@@ -181,7 +180,7 @@ substVarsWith
 substVarsWith topVars resultType argType = subst Set.empty argType
   where
     topVars' = reverse topVars
-    AppT resultType' indexType = resultType
+    AppT resultType' _indexType = resultType
     subst bs = \case
       ForallT bndrs cxt t ->
         let bs' = Set.union bs (Set.fromList (map tyVarBndrName bndrs))

--- a/src/Data/Aeson/GADT/TH.hs
+++ b/src/Data/Aeson/GADT/TH.hs
@@ -211,7 +211,6 @@ substVarsWith topVars resultType argType = subst Set.empty argType
       ConstraintT -> ConstraintT
       LitT l -> LitT l
       WildCardT -> WildCardT
-    findVar v _ _ | VarT v == indexType = v
     findVar v (tv:_) (AppT _ (VarT v')) | v == v' = tv
     findVar v (_:tvs) (AppT t (VarT _)) = findVar v tvs t
     findVar v _ _ = error $ "substVarsWith: couldn't look up variable substitution for " <> show v


### PR DESCRIPTION
* Extend type variable substitution to handle all current cases in template-haskell.
* Better deal with data constructors having an index that is polymorphic, but can be determined from the
other type parameters.
* Handle data constructors that are constrained by type classes.