### PR TITLE
Remove dependency on `th-extras` and support GHC 9.0

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     strategy:
       matrix:
-        ghc: ['8.0.2', '8.2.2', '8.4.4', '8.6.5', '8.8.4', '8.10.2']
+        ghc: ['8.0.2', '8.2.2', '8.4.4', '8.6.5', '8.8.4', '8.10.2', '9.0.1']
         os: ['ubuntu-latest', 'macos-latest']
         exclude:
           # There are some linker warnings in 802 on darwin that

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,7 @@
 
 * Remove dependency on `th-extras`. We were just using a reexport (under a
   different name) of something from `th-abstractions` anyways.
+* Support GHC 9.0
 
 ## 0.2.5.0 - 2020-11-18
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,10 @@
 # Revision history for aeson-gadt-th
 
+## Unreleased
+
+* Remove dependency on `th-extras`. We were just using a reexport (under a
+  different name) of something from `th-abstractions` anyways.
+
 ## 0.2.5.0 - 2020-11-18
 
 * Support for GHC 8.10

--- a/aeson-gadt-th.cabal
+++ b/aeson-gadt-th.cabal
@@ -27,7 +27,6 @@ library
                , transformers >= 0.5 && < 0.6
                , template-haskell >= 2.11.0 && < 2.17
                , th-abstraction >= 0.2.8.0 && < 0.4
-               , th-extras >= 0.0.0.4 && < 0.1
   if impl(ghc < 8.2)
     build-depends: dependent-sum < 0.6.2.2
   hs-source-dirs: src

--- a/aeson-gadt-th.cabal
+++ b/aeson-gadt-th.cabal
@@ -20,13 +20,13 @@ flag build-readme
 
 library
   exposed-modules: Data.Aeson.GADT.TH
-  build-depends: base >= 4.8 && < 4.15
+  build-depends: base >= 4.8 && < 4.16
                , aeson >= 1.3 && < 1.6
                , containers >= 0.5 && < 0.7
                , dependent-sum >= 0.4 && < 0.8
                , transformers >= 0.5 && < 0.6
-               , template-haskell >= 2.11.0 && < 2.17
-               , th-abstraction >= 0.2.8.0 && < 0.4
+               , template-haskell >= 2.11.0 && < 2.18
+               , th-abstraction >= 0.4 && < 0.5
   if impl(ghc < 8.2)
     build-depends: dependent-sum < 0.6.2.2
   hs-source-dirs: src

--- a/src/Data/Aeson/GADT/TH.hs
+++ b/src/Data/Aeson/GADT/TH.hs
@@ -44,7 +44,8 @@ import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.Some (Some(..))
 import Language.Haskell.TH hiding (cxt)
-import Language.Haskell.TH.Datatype (ConstructorInfo(..), applySubstitution, datatypeCons, reifyDatatype, tvName, unifyTypes)
+import Language.Haskell.TH.Datatype (ConstructorInfo(..), applySubstitution, datatypeCons, reifyDatatype, unifyTypes)
+import Language.Haskell.TH.Datatype.TyVarBndr (TyVarBndr_, tvName)
 
 #if MIN_VERSION_dependent_sum(0,5,0)
 #else
@@ -265,7 +266,7 @@ kindArity = \case
 -- its declaration, and the arity of the kind of type being defined (i.e. how many more arguments would
 -- need to be supplied in addition to the bound parameters in order to obtain an ordinary type of kind *).
 -- If the supplied 'Name' is anything other than a data or newtype, produces an error.
-tyConArity' :: Name -> Q ([TyVarBndr], Int)
+tyConArity' :: Name -> Q ([TyVarBndr_ ()], Int)
 tyConArity' n = reify n >>= return . \case
   TyConI (DataD _ _ ts mk _ _) -> (ts, maybe 0 kindArity mk)
   TyConI (NewtypeD _ _ ts mk _ _) -> (ts, maybe 0 kindArity mk)

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -23,6 +23,30 @@ pattern Some :: tag a -> Some tag
 pattern Some x = This x
 #endif
 
+data Foo a where
+  Bar :: Char -> Foo Char
+  Baz :: Float -> Foo Float
+
+deriving instance Show (Foo a)
+deriving instance Eq (Foo a)
+
+instance GShow Foo where gshowsPrec = showsPrec
+
+data Spam a where
+  Spam'Eggs :: Char -> Spam Char
+  Spam'Life :: Float -> Spam Float
+
+deriving instance Show (Spam a)
+deriving instance Eq (Spam a)
+
+instance GShow Spam where gshowsPrec = showsPrec
+
+deriveJSONGADT ''Foo
+
+deriveJSONGADTWithOptions
+  (JSONGADTOptions { gadtConstructorModifier = drop 5 })
+  ''Spam
+
 main :: IO ()
 main = hspec $ do
   describe "aeson-gadt-th" $ do
@@ -47,27 +71,3 @@ main = hspec $ do
         `shouldMatchPattern_` (\case Success (Some (Spam'Life 1.2)) -> ())
       (fromJSON [aesonQQ| ["bad", "input"] |] :: Result (Some Spam))
         `shouldMatchPattern_` (\case Error "Expected tag to be one of [Eggs, Life] but got: bad" -> ())
-
-data Foo a where
-  Bar :: Char -> Foo Char
-  Baz :: Float -> Foo Float
-
-deriving instance Show (Foo a)
-deriving instance Eq (Foo a)
-
-instance GShow Foo where gshowsPrec = showsPrec
-
-data Spam a where
-  Spam'Eggs :: Char -> Spam Char
-  Spam'Life :: Float -> Spam Float
-
-deriving instance Show (Spam a)
-deriving instance Eq (Spam a)
-
-instance GShow Spam where gshowsPrec = showsPrec
-
-deriveJSONGADT ''Foo
-
-deriveJSONGADTWithOptions
-  (JSONGADTOptions { gadtConstructorModifier = drop 5 })
-  ''Spam


### PR DESCRIPTION
We were just using a reexport (under a different name) of something from
`th-abstractions` anyways.