### PR TITLE
Support GHC 9.2

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -1,29 +1,24 @@
 name: github-action
 
-on: [push, pull_request] 
+on: [push, pull_request]
 
 jobs:
   build:
     strategy:
       matrix:
-        ghc: ['8.0.2', '8.2.2', '8.4.4', '8.6.5', '8.8.4', '8.10.2', '9.0.1']
+        ghc: ['8.4.4', '8.6.5', '8.8.4', '8.10.7', '9.0.2', '9.2.5', '9.4.5', '9.6.1']
         os: ['ubuntu-latest', 'macos-latest']
-        exclude:
-          # There are some linker warnings in 802 on darwin that
-          # cause compilation to fail
-          # See https://github.com/NixOS/nixpkgs/issues/25139
-          - ghc: '8.0.2'
-            os: 'macos-latest'
     runs-on: ${{ matrix.os }}
 
     name: GHC ${{ matrix.ghc }} on ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-haskell@v1
+    - uses: actions/checkout@v3
+    - uses: haskell/actions/setup@v2
       with:
         ghc-version: ${{ matrix.ghc }}
+        cabal-version: '3.10.1.0'
     - name: Cache
-      uses: actions/cache@v1
+      uses: actions/cache@v3
       env:
         cache-name: cache-cabal
       with:
@@ -36,10 +31,12 @@ jobs:
           ${{ runner.os }}
 
     - name: Install dependencies
-      run: |
-        cabal update
-        cabal build --only-dependencies --enable-tests --enable-benchmarks
+      run: cabal build --only-dependencies --enable-tests --enable-benchmarks
     - name: Build
       run: cabal build --enable-tests --enable-benchmarks all
     - name: Run tests
-      run: cabal test all
+      run: cabal test --enable-tests all
+    - if: matrix.ghc != '8.4.4'
+      # docs aren't built on ghc 8.4.4 because some dependency docs don't build on older GHCs
+      name: Build Docs
+      run: cabal haddock

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     strategy:
       matrix:
-        ghc: ['8.0.2', '8.2.2', '8.4.4', '8.6.5', '8.8.4', '8.10.2', '9.0.1']
+        ghc: ['8.0.2', '8.2.2', '8.4.4', '8.6.5', '8.8.4', '8.10.2', '9.0.1', '9.2.1']
         os: ['ubuntu-latest', 'macos-latest']
         exclude:
           # There are some linker warnings in 802 on darwin that

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # Revision history for aeson-gadt-th
 
+## Unreleased
+
+* Support GHC 9.2
+
 ## 0.2.5.1 - 2022-01-04
 
 * Remove dependency on `th-extras`. We were just using a reexport (under a

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # Revision history for aeson-gadt-th
 
+## 0.2.5.2 - 2022-07-03
+
+* Loosen version bounds
+
 ## 0.2.5.1 - 2022-01-04
 
 * Remove dependency on `th-extras`. We were just using a reexport (under a

--- a/aeson-gadt-th.cabal
+++ b/aeson-gadt-th.cabal
@@ -21,7 +21,7 @@ flag build-readme
 library
   exposed-modules: Data.Aeson.GADT.TH
   build-depends: base >= 4.8 && < 4.16
-               , aeson >= 1.3 && < 1.6
+               , aeson >= 1.3 && < 2.3
                , containers >= 0.5 && < 0.7
                , dependent-sum >= 0.4 && < 0.8
                , transformers >= 0.5 && < 0.6

--- a/aeson-gadt-th.cabal
+++ b/aeson-gadt-th.cabal
@@ -20,12 +20,12 @@ flag build-readme
 
 library
   exposed-modules: Data.Aeson.GADT.TH
-  build-depends: base >= 4.8 && < 4.16
-               , aeson >= 1.3 && < 1.6
+  build-depends: base >= 4.8 && < 4.17
+               , aeson >= 1.3 && < 2.1
                , containers >= 0.5 && < 0.7
                , dependent-sum >= 0.4 && < 0.8
                , transformers >= 0.5 && < 0.6
-               , template-haskell >= 2.11.0 && < 2.18
+               , template-haskell >= 2.11.0 && < 2.19
                , th-abstraction >= 0.4 && < 0.5
   if impl(ghc < 8.2)
     build-depends: dependent-sum < 0.6.2.2

--- a/src/Data/Aeson/GADT/TH.hs
+++ b/src/Data/Aeson/GADT/TH.hs
@@ -238,7 +238,14 @@ conMatches clsName topVars ixVar c = do
           [InstanceD _ cxt (AppT _className (AppT (ConT _some) ityp)) _] -> do
             sub <- lift $ unifyTypes [ityp, tn]
             tellCxt $ applySubstitution sub cxt
-            return (ConP 'Some [VarP x], VarE x)
+            return ( ConP
+                       'Some
+#if MIN_VERSION_template_haskell(2,18,0)
+                       []
+#endif
+                       [VarP x]
+                   , VarE x
+                   )
           _ -> error $ "The following instances of " ++ show clsName ++ " for " ++ show (ppr [AppT (ConT ''Some) tn]) ++ " exist (rigids: " ++ unwords (map show $ Set.toList rigidVars) ++ "), and I don't know which to pick:\n" ++ unlines (map (show . ppr) insts)
       _ -> do
         demandInstanceIfNecessary  


### PR DESCRIPTION
Draft because the test suite doesn't build because `haskell-src-meta` doesn't yet support 9.2.